### PR TITLE
Docker: ensure additional PHP configs are readable in local image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,9 +121,11 @@ RUN apk add --no-cache \
     jq \
     ;
 
-RUN mkdir /home/php/.config \
-    mkdir -p /home/php/.local/share/atuin \
+RUN set -xeo pipefail \
+    && mkdir /home/php/.config \
+    && mkdir -p /home/php/.local/share/atuin \
     && chown -R php:php /home/php \
+    && chmod a+r -R /etc/php84 \
     ;
 
 # Restore permissions on TMP folder


### PR DESCRIPTION
This solves the issue that the memory limit was set to 256Mb and not taken from the files copied from the conf.d-dev directory.