### PR TITLE
fix typo in prune registry query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 2.x
 
+## v2.0.11
+
+* [bugfix] Fix typo in prune registry query.
+
 ## v2.0.10
 
 * [bugfix] Cleanup how we use with-contenv to run s6 jobs.

--- a/src/Domain/BuildingData/Repository/BuildingEntranceRepository.php
+++ b/src/Domain/BuildingData/Repository/BuildingEntranceRepository.php
@@ -209,7 +209,7 @@ final class BuildingEntranceRepository extends ServiceEntityRepository implement
         $importDateBefore = $this->clock->now()->sub(new \DateInterval("P{$activeDays}D"));
 
         $qb = $this->createQueryBuilder('b')
-            ->where('b.importedAt <=  :importedat')
+            ->where('b.importedAt <=  :importedAt')
             ->setParameter('importedAt', $importDateBefore, Types::DATETIME_IMMUTABLE)
         ;
 

--- a/tests/Functional/BuildingData/BuildingEntranceRepositoryTest.php
+++ b/tests/Functional/BuildingData/BuildingEntranceRepositoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\BuildingData;
+
+use App\Domain\BuildingData\Entity\BuildingEntrance;
+use App\Domain\BuildingData\Repository\BuildingEntranceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class BuildingEntranceRepositoryTest extends KernelTestCase
+{
+    private BuildingEntranceRepository $repository;
+
+    protected function setUp(): void
+    {
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->repository = $em->getRepository(BuildingEntrance::class);
+    }
+
+    public function testPrune(): void
+    {
+        $this->assertSame(0, $this->repository->deleteOutdatedBuildingEntrances(90));
+    }
+}


### PR DESCRIPTION
 add functional test that would have discovered the typo